### PR TITLE
fixed indentation of command/code samples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,25 +24,25 @@ Release branch names follow the same convention in both kohana/kohana and kohana
 
 To work on 3.3.x you'd do the following:
 
-  > git clone git://github.com/kohana/kohana.git
-  # ....
-  
-  > cd kohana
-  > git submodule update --init
-  # ....
+    > git clone git://github.com/kohana/kohana.git
+    # ....
 
-  > git checkout 3.3/develop
-  # Switched to branch '3.3/develop'
-  
-  > git submodule foreach "git fetch && git checkout 3.3/develop"
-        # ...
+    > cd kohana
+    > git submodule update --init
+    # ....
+
+    > git checkout 3.3/develop
+    # Switched to branch '3.3/develop'
+
+    > git submodule foreach "git fetch && git checkout 3.3/develop"
+    # ...
 
 It's important that you follow the last step, because unlike svn, git submodules point at a
 specific commit rather than the tip of a branch.  If you cd into the system folder after
 a `git submodule update` and run `git status` you'll be told:
 
-  # Not currently on any branch.
-  nothing to commit (working directory clean)
+    # Not currently on any branch.
+    nothing to commit (working directory clean)
 
 ***
 
@@ -61,33 +61,33 @@ until they're stable.
 
 The naming convention for feature branches is:
 
-  {version}/feature/{issue number}-{short hyphenated description}
-  
-  // e.g.
+    {version}/feature/{issue number}-{short hyphenated description}
 
-  3.2/feature/4045-rewriting-config-system
-  
+i.e.
+
+    3.2/feature/4045-rewriting-config-system
+
 When a new feature is complete and fully tested it can be merged into its respective release branch using
 `git pull --no-ff`. The `--no-ff` switch is important as it tells git to always create a commit
 detailing what branch you're merging from. This makes it a lot easier to analyse a feature's history.
 
 Here's a quick example:
 
-  > git status
-  # On branch 3.2/feature/4045-rewriting-everything
-  
-  > git checkout 3.1/develop
-  # Switched to branch '3.1/develop'
+    > git status
+    # On branch 3.2/feature/4045-rewriting-everything
 
-  > git merge --no-ff 3.2/feature/4045-rewriting-everything
+    > git checkout 3.1/develop
+    # Switched to branch '3.1/develop'
+
+    > git merge --no-ff 3.2/feature/4045-rewriting-everything
 
 **If a change you make intentionally breaks the api then please correct the relevant tests before pushing!**
 
-## Bug fixing 
+## Bug fixing
 
 If you're making a bugfix then before you start create a unit test which reproduces the bug,
 using the `@ticket` notation in the test to reference the bug's issue number
-(e.g. `@ticket 4045` for issue #4045). 
+(e.g. `@ticket 4045` for issue #4045).
 
 If you run the unit tests then the one you've just made should fail.
 
@@ -128,7 +128,7 @@ section [in the git-scm book](http://book.git-scm.com/3_basic_branching_and_merg
 
 The simplest way to fix this is to remove all the changes that you've made locally.
 
-You can do this using 
+You can do this using
 
     > git reset --hard kohana
 
@@ -145,7 +145,7 @@ Then find the hash of the offending local commit and run:
 
 i.e.
 
-  > git rebase -i 57d0b28
+    > git rebase -i 57d0b28
 
 A text editor will open with a list of commits, delete the line containing the offending commit
 before saving the file & closing your editor.


### PR DESCRIPTION
The indentation on some of the command examples was incorrect.
