### PR TITLE
fix github redirects breaking submodule updates by switching to https ur...

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "system"]
 	path = system
-	url = http://github.com/kohana/core.git
+	url = https://github.com/kohana/core.git
 [submodule "modules/codebench"]
 	path = modules/codebench
-	url = http://github.com/kohana/codebench.git
+	url = https://github.com/kohana/codebench.git
 [submodule "modules/database"]
 	path = modules/database
-	url = http://github.com/kohana/database.git
+	url = https://github.com/kohana/database.git
 [submodule "modules/image"]
 	path = modules/image
-	url = http://github.com/kohana/image.git
+	url = https://github.com/kohana/image.git
 [submodule "modules/orm"]
 	path = modules/orm
-	url = http://github.com/kohana/orm.git
+	url = https://github.com/kohana/orm.git
 [submodule "modules/auth"]
 	path = modules/auth
-	url = http://github.com/kohana/auth.git
+	url = https://github.com/kohana/auth.git
 [submodule "modules/userguide"]
 	path = modules/userguide
-	url = http://github.com/kohana/userguide.git
+	url = https://github.com/kohana/userguide.git
 [submodule "modules/cache"]
 	path = modules/cache
-	url = http://github.com/kohana/cache.git
+	url = https://github.com/kohana/cache.git
 [submodule "modules/unittest"]
 	path = modules/unittest
-	url = http://github.com/kohana/unittest.git
+	url = https://github.com/kohana/unittest.git
 [submodule "modules/minion"]
 	path = modules/minion
-	url = http://github.com/kohana/minion.git
+	url = https://github.com/kohana/minion.git


### PR DESCRIPTION
Just a small update to switch to https for submodule url since new clones now no longer able to `git submodule update` anymore.
