### PR TITLE
Enable modules before using I18n::lang()

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -66,6 +66,23 @@ mb_substitute_character('none');
 // -- Configuration and initialization -----------------------------------------
 
 /**
+ * Enable modules. Modules are referenced by a relative or absolute path.
+ */
+Kohana::modules([
+	'application' => APPPATH,             // Main application module
+	// 'auth'        => MODPATH.'auth',      // Basic authentication
+	// 'cache'       => MODPATH.'cache',     // Caching with multiple backends
+	// 'codebench'   => MODPATH.'codebench', // Benchmarking tool
+	// 'database'    => MODPATH.'database',  // Database access
+	// 'image'       => MODPATH.'image',     // Image manipulation
+	// 'minion'      => MODPATH.'minion',    // CLI Tasks
+	// 'orm'         => MODPATH.'orm',       // Object Relationship Mapping
+	// 'unittest'    => MODPATH.'unittest',  // Unit testing
+	// 'userguide'   => MODPATH.'userguide', // User guide and API documentation
+	'core'        => SYSPATH,             // Core system
+]);
+
+/**
  * Set the default language
  */
 I18n::lang('en-us');
@@ -109,23 +126,6 @@ Kohana::$log->attach(new Log_File(APPPATH.'logs'));
  * Attach a file reader to config. Multiple readers are supported.
  */
 Kohana::$config->attach(new Config_File);
-
-/**
- * Enable modules. Modules are referenced by a relative or absolute path.
- */
-Kohana::modules(array(
-	'application' => APPPATH,             // Main application module
-	// 'auth'        => MODPATH.'auth',      // Basic authentication
-	// 'cache'       => MODPATH.'cache',     // Caching with multiple backends
-	// 'codebench'   => MODPATH.'codebench', // Benchmarking tool
-	// 'database'    => MODPATH.'database',  // Database access
-	// 'image'       => MODPATH.'image',     // Image manipulation
-	// 'minion'      => MODPATH.'minion',    // CLI Tasks
-	// 'orm'         => MODPATH.'orm',       // Object Relationship Mapping
-	// 'unittest'    => MODPATH.'unittest',  // Unit testing
-	// 'userguide'   => MODPATH.'userguide', // User guide and API documentation
-	'core'        => SYSPATH,             // Core system
-	));
 
 /**
  * Set the routes. Each route must have a minimum of a name, a URI and a set of


### PR DESCRIPTION
The core module needs to be enabled before using the I18n class. The reason it worked before was because the core module was enabled by default before Kohana::modules() was even called.
