### PR TITLE
Add i18n translate alias function to bootstrap

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -87,6 +87,15 @@ Kohana::modules([
  */
 I18n::lang('en-us');
 
+// Define i18n translate alias function
+if ( ! function_exists('__'))
+{
+	function __($string, array $values = NULL, $lang = 'en-us')
+	{
+		return I18n::translate($string, $values, $lang);
+	}
+}
+
 /**
  * Set Kohana::$environment if a 'KOHANA_ENV' environment variable has been supplied.
  *


### PR DESCRIPTION
Related to https://github.com/kohana/core/issues/526

When implementing I realised that I18n::lang() had to be set for the function to be useful, so in the end it did have to be placed after Kohana::modules().
