### PR TITLE
Fix travis build and test execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ before_install:
   - "git submodule update --init --recursive"
 
 before_script:
-  - "pear channel-discover pear.phing.info"
-  - "pear install phing/phing"
   - "phpenv rehash"
   - "composer install"
 
-script: "phing test"
+script: "vendor/bin/phing test"
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 before_script:
   - "phpenv rehash"
-  - "composer install"
+  - "composer install --prefer-dist"
 
 script: "vendor/bin/phing test"
 


### PR DESCRIPTION
The travis build for 3.3 and 3.4 is currently broken, and the unit tests are failing because of a conflict between PHPUnit and Kohana over the management of superglobals.

This pull will ultimately get it running again for 3.3, and then we can merge it up into 3.4.
