### PR TITLE
[WIP Proposal] Extract bootstrapping from index.php, handle all in bootstrap.php

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -1,4 +1,53 @@
-<?php defined('SYSPATH') or die('No direct script access.');
+<?php
+
+/**
+ * Set the PHP error reporting level. If you set this in php.ini, you remove this.
+ * @link http://www.php.net/manual/errorfunc.configuration#ini.error-reporting
+ *
+ * When developing your application, it is highly recommended to enable notices
+ * and strict warnings. Enable them by using: E_ALL | E_STRICT
+ *
+ * In a production environment, it is safe to ignore notices and strict warnings.
+ * Disable them by using: E_ALL ^ E_NOTICE
+ *
+ * When using a legacy application with PHP >= 5.3, it is recommended to disable
+ * deprecated notices. Disable with: E_ALL & ~E_DEPRECATED
+ */
+error_reporting(E_ALL | E_STRICT);
+
+/**
+ * The directories in which your application, modules, system and document root (web-accessible files) are located.
+ *
+ * @link http://kohanaframework.org/guide/about.install#application
+ */
+define('APPPATH', realpath(__DIR__).DIRECTORY_SEPARATOR);
+define('MODPATH', realpath(__DIR__.'/../modules').DIRECTORY_SEPARATOR);
+define('SYSPATH', realpath(__DIR__.'/../system').DIRECTORY_SEPARATOR);
+define('DOCROOT', realpath(__DIR__.'/../').DIRECTORY_SEPARATOR);
+
+/**
+ * The default extension of resource files. If you change this, all resources
+ * must be renamed to use the new extension.
+ *
+ * @link http://kohanaframework.org/guide/about.install#ext
+ */
+define('EXT', '.php');
+
+/**
+ * Define the start time of the application, used for profiling.
+ */
+if ( ! defined('KOHANA_START_TIME'))
+{
+	define('KOHANA_START_TIME', microtime(TRUE));
+}
+
+/**
+ * Define the memory usage at the start of the application, used for profiling.
+ */
+if ( ! defined('KOHANA_START_MEMORY'))
+{
+	define('KOHANA_START_MEMORY', memory_get_usage());
+}
 
 // -- Environment setup --------------------------------------------------------
 

--- a/index.php
+++ b/index.php
@@ -1,106 +1,13 @@
 <?php
-/**
- * Set the PHP error reporting level. If you set this in php.ini, you remove this.
- * @link http://www.php.net/manual/errorfunc.configuration#ini.error-reporting
- *
- * When developing your application, it is highly recommended to enable notices
- * and strict warnings. Enable them by using: E_ALL | E_STRICT
- *
- * In a production environment, it is safe to ignore notices and strict warnings.
- * Disable them by using: E_ALL ^ E_NOTICE
- *
- * When using a legacy application with PHP >= 5.3, it is recommended to disable
- * deprecated notices. Disable with: E_ALL & ~E_DEPRECATED
- */
-error_reporting(E_ALL | E_STRICT);
-
-/**
- * Set paths
- */
-$paths = array(
-	/**
-	 * The directory in which your application specific resources are located.
-	 * The application directory must contain the bootstrap.php file.
-	 *
-	 * @link http://kohanaframework.org/guide/about.install#application
-	 */
-	'APPPATH' => 'application',
-
-	/**
-	 * The directory in which your modules are located.
-	 *
-	 * @link http://kohanaframework.org/guide/about.install#modules
-	 */
-	'MODPATH' => 'modules',
-
-	/**
-	 * The directory in which the Kohana resources are located. The system
-	 * directory must contain the classes/kohana.php file.
-	 *
-	 * @link http://kohanaframework.org/guide/about.install#system
-	 */
-	'SYSPATH' => 'system',
-);
-
-/**
- * The default extension of resource files. If you change this, all resources
- * must be renamed to use the new extension.
- *
- * @link http://kohanaframework.org/guide/about.install#ext
- */
-define('EXT', '.php');
-
-/**
- * End of standard configuration! Changing any of the code below should only be
- * attempted by those with a working knowledge of Kohana internals.
- *
- * @link http://kohanaframework.org/guide/using.configuration
- */
-
-// Set the full path to the docroot
-define('DOCROOT', realpath(dirname(__FILE__)).DIRECTORY_SEPARATOR);
-
-// For each path set
-foreach ($paths as $key => $path)
-{
-	// Make the path relative to the docroot, for symlink'd index.php
-	if ( ! is_dir($path) AND is_dir(DOCROOT.$path))
-	{
-		$path = DOCROOT.$path;
-	}
-	
-	// Define the absolute path
-	define($key, realpath($path).DIRECTORY_SEPARATOR);
-}
-
-// Clean up the configuration vars
-unset($paths);
+// Bootstrap the application - modify this path if required
+require __DIR__.'/application/bootstrap.php';
 
 // If installation file exists
-if (file_exists('install'.EXT))
+if (file_exists(DOCROOT.'install'.EXT))
 {
 	// Load the installation check
-	return include 'install'.EXT;
+	return include DOCROOT.'install'.EXT;
 }
-
-/**
- * Define the start time of the application, used for profiling.
- */
-if ( ! defined('KOHANA_START_TIME'))
-{
-	define('KOHANA_START_TIME', microtime(TRUE));
-}
-
-/**
- * Define the memory usage at the start of the application, used for profiling.
- */
-if ( ! defined('KOHANA_START_MEMORY'))
-{
-	define('KOHANA_START_MEMORY', memory_get_usage());
-}
-
-// Bootstrap the application
-require APPPATH.'bootstrap'.EXT;
 
 // If PHP build's server API is CLI
 if (PHP_SAPI == 'cli')


### PR DESCRIPTION
There is currently no clear separation between index.php and bootstrap.php - both files have to be run to bootstrap a complete environment, but loading index.php then always attempts to run either a web request or a 
minion task.

This means the bit of bootstrapping that happens in index.php has to be partially duplicated in the unittest module and also in any end-user projects that want to make the kohana environment available to other CLI or web tools (eg PHPUnit, Behat, Doctrine, etc). This causes maintenance issues if the default path structure changes, or if you want to use a non-standard directory layout. It additionally makes it more tricky than it should be to move the index.php down to an explicit web document root for security. I explained the issue more in http://dev.kohanaframework.org/issues/4777 last year.

I'd appreciate feedback/agreement on this proposal before I finish off making the required changes to unittest and minion to support it.
