### PR TITLE
Isolate the visible part of an application inside a public folder.

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -103,7 +103,7 @@ if (isset($_SERVER['KOHANA_ENV']))
  * - boolean  expose      set the X-Powered-By header                        FALSE
  */
 Kohana::init(array(
-	'base_url'   => '/kohana/',
+	'base_url'   => '/kohana/public/',
 ));
 
 /**

--- a/index.php
+++ b/index.php
@@ -76,10 +76,11 @@ define('SYSPATH', realpath($system).DIRECTORY_SEPARATOR);
 // Clean up the configuration vars
 unset($application, $modules, $system);
 
-if (file_exists('install'.EXT))
+// If installation file exists
+if (file_exists(DOCROOT.'install'.EXT))
 {
 	// Load the installation check
-	return include 'install'.EXT;
+	return include DOCROOT.'install'.EXT;
 }
 
 /**

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,1 @@
+../index.php


### PR DESCRIPTION
`index.php` is symlinked in the public folder.

`install.php` was included relatively to the index.php location,
which is not right if the application is accessed form a symlink of
index.php. The inclusion is now relative to `DOCROOT`.

This is essential when you have to hide files like `composer.json` or
`phinx.yml` containing sensitive information.
