### PR TITLE
Merge 3.3/develop up to 3.4/develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,7 @@ before_script:
   - "composer install --prefer-dist"
 
 script:
-  # Standard build script
-  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then vendor/bin/phing test; fi
-  # HHVM script (phing not currently supported on hhvm pending http://www.phing.info/trac/ticket/1086)
-  - if [[ $TRAVIS_PHP_VERSION == "hhvm" ]] ; then ./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap_all_modules.php modules/unittest/tests.php ; fi
+  - vendor/bin/phing test
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,17 @@ php:
   - 7.0
   - hhvm
 
+matrix:
+  include:
+    - php: 5.3
+      env: 'COMPOSER_PHPUNIT="lowest"'
+
 before_install:
   - "git submodule update --init --recursive"
 
 before_script:
   - "composer install --prefer-dist"
+  - if [ "$COMPOSER_PHPUNIT" = "lowest" ]; then composer update --prefer-lowest --with-dependencies phpunit/phpunit; fi;
 
 script:
   - vendor/bin/phing test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ a `git submodule update` and run `git status` you'll be told:
 
 # Contributing to the project
 
-All features and bugfixes must be fully tested and reference an issue in the [tracker](http://dev.kohanaframework.org/projects/kohana3), **there are absolutely no exceptions**.
+All features and bugfixes must be fully tested and reference an issue in  [GitHub](https://github.com/kohana/kohana/issues), **there are absolutely no exceptions**.
 
 It's highly recommended that you write/run unit tests during development as it can help you pick up on issues early on.  See the Unit Testing section below.
 

--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -132,6 +132,15 @@ Kohana::modules(array(
 	));
 
 /**
+ * Cookie Salt
+ * @see  http://kohanaframework.org/3.3/guide/kohana/cookies
+ * 
+ * If you have not defined a cookie salt in your Cookie class then
+ * uncomment the line below and define a preferrably long salt.
+ */
+// Cookie::$salt = NULL;
+
+/**
  * Set the routes. Each route must have a minimum of a name, a URI and a set of
  * defaults for the URI.
  */

--- a/build.xml
+++ b/build.xml
@@ -167,13 +167,13 @@
 
 	<!-- Run unit tests -->
 	<target name="test">
-		<exec command="./vendor/phpunit/phpunit/composer/bin/phpunit --bootstrap=modules/unittest/bootstrap_all_modules.php modules/unittest/tests.php" checkreturn="true" passthru="true"/>
+		<exec command="./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap_all_modules.php modules/unittest/tests.php" checkreturn="true" passthru="true"/>
 	</target>
 
 
 	<!-- Run unit tests and generate junit.xml and clover.xml -->
 	<target name="test-log">
-<exec command="phpunit --bootstrap=modules/unittest/bootstrap_all_modules.php --coverage-html='${builddir}/coverage' --log-junit='${builddir}/logs/junit.xml' --coverage-clover='${builddir}/logs/clover.xml' modules/unittest/tests.php" checkreturn="true" passthru="true"/>
+		<exec command="./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap_all_modules.php --coverage-html='${builddir}/coverage' --log-junit='${builddir}/logs/junit.xml' --coverage-clover='${builddir}/logs/clover.xml' modules/unittest/tests.php" checkreturn="true" passthru="true"/>
 	</target>
 
 	<!-- Run PHP Code Sniffer -->

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"require": {
-		"phpunit/phpunit": "3.7.24",
+		"phpunit/phpunit": "3.7.24 - 4",
 		"phing/phing": "dev-master"
 	}
 }


### PR DESCRIPTION
This merge up of bugfixes etc does not currently pass because it depends on kohana/userguide#84 to fix the PHP7 support in that module.

Once that's merged it should be possible to rerun the PHP7 test for this pull and get a green tick.
