### PR TITLE
Remove explicit phpunit dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
 		"kohana/orm": "3.4.*"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "3.7.24 - 4",
 		"phing/phing": "dev-master",
 		"kohana/unittest": "3.4.*",
 		"kohana/userguide": "3.4.*"


### PR DESCRIPTION
There is already a dependency via the requirement for
kohana/unittest, which is maintained to specify the appropriate
phpunit version for each kohana release series.

Requiring phpunit here is redundant and potentially conflicting.

Resolves #88, thanks to @16nsk for highlighting the problem.
