### PR TITLE
Optimise travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ branches:
   only:
     - /^[0-9\.]+\/(develop|master)$/
 
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: false
 
 language: php
 
+# Only build the main develop/master branches - feature branches will be covered by PRs
+branches:
+  only:
+    - /^[0-9\.]+\/(develop|master)$/
+
 php:
   - 5.3
   - 5.4


### PR DESCRIPTION
Our development workflow requires that even contributions by
core committers are made through pull requests, but often for
simplicity these are done using feature/bug branches on the
main repository (rather than in a fork).

This is causing travis to build each such commit twice - once
triggered by the push to the feature branch and once by the
pull request. This is asking them to do unnecessary work (which
seems rude) and slightly confuses commit status and feedback.

With this change, travis will ignore pushes on branches other than
x.x/master|x.x/develop - other branches will only be built if and
when they appear in a PR.

Also added caching of composer dependencies.
